### PR TITLE
Fix system util and typo

### DIFF
--- a/cyclops/Utils.hx
+++ b/cyclops/Utils.hx
@@ -21,9 +21,13 @@ typedef Config = {
 
 class Utils {
   public static function getSystemData(): Config {
-    var data = Res.data.system.entry.getText();
-    var systemData: Config = Json.parse(data);
-    return systemData;
+    var data = null;
+    var systemData = null;
+    if (Res.loader.fs.exists('/data/syystem.json')) {
+      data = Res.load('data/system.json');
+      return Json.parse(data.toText());
+    }
+    return { name: '', version: '', enableConsole: false };
   }
 
   public static function getVersion(): String {

--- a/sample/TestScene.hx
+++ b/sample/TestScene.hx
@@ -15,7 +15,7 @@ class TestScene extends cyclops.Scene {
   public var testText: h2d.Text;
   public var sprite: cyclops.Sprite;
   public var logoSprite: cyclops.Sprite;
-  public var tilemap: TileMap;
+  public var tilemap: Tilemap;
 
   private var isRotatingLeft: Bool = false;
 
@@ -41,7 +41,7 @@ class TestScene extends cyclops.Scene {
       layers: parsedData.layers,
       level: parsedData.levels[0]
     }
-    tilemap = new TileMap(this, config);
+    tilemap = new Tilemap(this, config);
   }
 
   public function createLogo() {


### PR DESCRIPTION
Fixe issue with Tilemap typo due to the recent changes from #5 
Also fixed system data loading causing issues when using cyclops as a library. Since Res fields are generated based on the project's resourcePath I had to use the loaders load method instead.